### PR TITLE
Resolve #6 "Error: expected file.path to export a function or instance "

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/lib/generator')
+module.exports = require('./dist/lib/generator').default


### PR DESCRIPTION
Fix #6 

Exports `require('./dist/lib/generator').default` instead of `require('./dist/lib/generator')` due to babel transpilation